### PR TITLE
exit stops messages

### DIFF
--- a/src/Console/ImportDelimitedCommand.php
+++ b/src/Console/ImportDelimitedCommand.php
@@ -93,9 +93,19 @@ class ImportDelimitedCommand extends Command
             return;
         }
 
-        $this->parseArguments();
+        try {
+            
+            $this->parseArguments();
 
-        $this->runImport();
+            $this->runImport();    
+
+        } catch (ImportDelimitedException $e) {
+
+            throw new \RuntimeException($e->getMessage());
+            
+        }
+        
+        return;
 
     }
 
@@ -560,13 +570,12 @@ class ImportDelimitedCommand extends Command
      */
     protected function abort($message, $code = 1)
     {
-        $this->comment("Error(L{$this->fileLine}): $message");
 
         if ($this->imported > 0) {
             $this->reportImported();
         }
 
-        exit($code);
+        throw new ImportDelimitedException($message, $code);
     }
 
     /**

--- a/src/Console/ImportDelimitedCommand.php
+++ b/src/Console/ImportDelimitedCommand.php
@@ -88,8 +88,9 @@ class ImportDelimitedCommand extends Command
      */
     public function handle()
     {
-        if (! $this->confirmToProceed()) {
-            exit(1);
+        
+        if (!$this->confirmToProceed()) {
+            return;
         }
 
         $this->parseArguments();

--- a/src/Console/ImportDelimitedException.php
+++ b/src/Console/ImportDelimitedException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace ArtisanIo\Console;
+
+class ImportDelimitedException extends \Exception
+{
+}


### PR DESCRIPTION
When running **\Artisan::call('import:delimited', [])** errors will not be collected/shown when using exit. I made a simple exception to catch then push out a runtime error.
