### PR TITLE
Added info on how to get it up and running in Lumen

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ protected $commands = [
 
 ### Installation in Lumen
 
-Follow the above steps and then open upp `app\Providers\AppServiceProvider.php` in the ditor of your choice and add the following to the register method:
+Follow the above steps and then open upp `app\Providers\AppServiceProvider.php` in the editor of your choice and add the following to the register method:
 
 ```php
 $this->app->bind('Symfony\Component\Translation\TranslatorInterface', function ($app) {

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,15 @@ protected $commands = [
 ];
 ```
 
+### Installation in Lumen
+
+Follow the above steps and then open upp `app\Providers\AppServiceProvider.php` in the ditor of your choice and add the following to the register method:
+
+```php
+$this->app->bind('Symfony\Component\Translation\TranslatorInterface', function ($app) {
+    return $app['translator'];
+});
+```
 
 ## Usage
 


### PR DESCRIPTION
It doesn't work in Lumen without the following instrucitons. Out of the box it renders the following error:
 [RuntimeException]
  Target [Symfony\Component\Translation\TranslatorInterface] is not instantia
  ble while building [ArtisanIo\Delimited\ModelImport, Illuminate\Validation\
  Factory].